### PR TITLE
Update GitHub Actions Workflow to Build and Push Docker Image

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,32 +1,36 @@
-name: Deploy Images to GHCR
-
-env:
-  DOTNET_VERSION: '6.0.x'
+name: Build and Push Docker Image
 
 on:
-  push:
-    branches:
-      - main
-  workflow_dispatch:
+    push:
+        branches:
+            - main
+
+env:
+    REGISTRY: ghcr.io
+    IMAGE_NAME: ${{github.repository}}
 
 jobs:
-      push-morbo-image:
+    build-and-push-morbo-image:
         runs-on: ubuntu-latest
-        defaults:
-          run:
-            working-directory: './morbo'
+        permissions:
+            contents: read
+            packages: write
+
         steps:
-          - name: 'Checkout GitHub Action'
-            uses: actions/checkout@main
+            - name: "Checkout Repository"
+              uses: actions/checkout@v4
 
-          - name: 'Login to GitHub Container Registry'
-            uses: docker/login-action@v1
-            with:
-              registry: ghcr.io
-              username: ${{github.actor}}
-              password: ${{secrets.GITHUB_TOKEN}}
-
-          - name: 'Build Morbo Image'
-            run: |
-              docker build . --tag ghcr.io/zluigon/morbo:latest
-              docker push ghcr.io/zluigon/morbo:latest
+            - name: "Login to GitHub Container Registry"
+              uses: docker/login-action@v1
+              with:
+                  registry: ${{env.REGISTRY}}
+                  username: ${{github.actor}}
+                  password: ${{secrets.GITHUB_TOKEN}}
+            
+            - name: "Build and push Docker image"
+              uses: docker/build-push-action@v4
+              with:
+                context: .
+                push: true
+                tags: ${{env.REGISTRY}}/${{env.IMAGE_NAME}}:latest
+                file: ./morbo/Dockerfile


### PR DESCRIPTION
- Modified build.yaml workflow file
- Changed job name from 'push-morbo-image' to 'build-and-push-morbo-image'
- Added registry environment variable for GHCR
- Added image_name environment variable using github context
- Updated permissions to include contents read and packages write
- Replaced manual docker build/push steps with the official docker/build-push-action